### PR TITLE
set the output folder in the write_latex function

### DIFF
--- a/R/build_functions.R
+++ b/R/build_functions.R
@@ -37,11 +37,11 @@ summarise_chapter_df <- function(X) {
       tex_chapter = paste0("\\chapter{", month_name, "}", tex_chapter)
     ) |>
     dplyr::mutate(
-      path = file.path(Sys.getenv("OUTPATH"), paste0(month, ".tex"))
+      path = file.path(paste0(month, ".tex"))
     )
 }
 
-write_latex <- function(chapters) {
-  purrr::walk(dirname(chapters$path), dir.create, recursive = TRUE, showWarnings = FALSE)
-  purrr::walk2(.x = chapters$tex_chapter, .y = chapters$path, .f = readr::write_file)
+write_latex <- function(chapters, output_location = '.') {
+  purrr::walk(dirname(file.path(output_location, chapters$path)), dir.create, recursive = TRUE, showWarnings = FALSE)
+  purrr::walk2(.x = chapters$tex_chapter, .y = file.path(output_location, chapters$path), .f = readr::write_file)
 }

--- a/pages2tex.R
+++ b/pages2tex.R
@@ -9,4 +9,4 @@ source_folder(year = this_year, month = this_month) |>
   pages_df() |>
   create_chapter_df() |>
   summarise_chapter_df() |>
-  write_latex()
+  write_latex(output_location = Sys.getenv("OUTPATH"))


### PR DESCRIPTION
Previously the output folder was defined when creating the chapter data frame. Now it is only set when the output is written to disk by the `write_latex` function.