### PR TITLE
Turn scripts into functions

### DIFF
--- a/R/full-year.R
+++ b/R/full-year.R
@@ -1,31 +1,37 @@
 library(pages2df)
 
-source("R/write-latex.R")
+full_year <- function(pagespath, output_location) {
 
-# source folder needs to modified slightly
-X <- file.path(Sys.getenv("PAGESPATH"), "src", 22) 
+  # the only change is recursive = TRUE
+  # does that work in the monthly case as well?
+  X <- tibble::tibble(
+      paths = list.files(pagespath, full.names = TRUE, recursive = TRUE)
+    ) |>
+    dplyr::mutate(
+      ymd = lubridate::ymd(gsub(".md", "", basename(paths)))
+    ) |>
+    dplyr::mutate(
+      text = purrr::map_chr(paths, readr::read_file)
+    )
+  
+  # this works (not sure where the NA month comes from)
+  chapters <- X |>
+    create_chapter_df() |>
+    create_chapters() |>
+    dplyr::filter(!is.na(month)) |>
+    dplyr::mutate(
+      path = file.path(paste0(month, ".tex"))
+    )
+  
+  purrr::walk(dirname(file.path(output_location, chapters$path)), dir.create, recursive = TRUE, showWarnings = FALSE)
+  purrr::walk2(.x = chapters$tex_chapter, .y = file.path(output_location, chapters$path), .f = readr::write_file)
 
-# the only change is recursive = TRUE
-# does that work in the monthly case as well?
-X <- tibble::tibble(
-    paths = list.files(X, full.names = TRUE, recursive = TRUE)
-  ) |>
-  dplyr::mutate(
-    ymd = lubridate::ymd(gsub(".md", "", basename(paths)))
-  ) |>
-  dplyr::mutate(
-    text = purrr::map_chr(paths, readr::read_file)
-  )
+}
 
-# this works (not sure where the NA month comes from)
-XX <- X |>
-  create_chapter_df() |>
-  create_chapters() |>
-  dplyr::filter(!is.na(month)) |>
-  dplyr::mutate(
-    path = file.path(paste0(month, ".tex"))
-  )
-
-# this is slightly different from the update script - which uses the OUTPATH environment variable (usually set to pagesbook-2024 folder)
-write_latex(XX, output_location = file.path("/Users/matthew/001_Project/Writing/Memoir/pagesbook-2022/src/chapter/"))
-
+# Full year export invocation
+#
+# output location is slightly different from pages2tex.R - which uses the OUTPATH environment variable (usually set to pagesbook-2024 folder)
+# full_year(
+#        pagespath = file.path(Sys.getenv("PAGESPATH"), "src", 22), 
+#  output_location = file.path("/Users/matthew/001_Project/Writing/Memoir/pagesbook-2022/src/chapter/")
+# )

--- a/R/pages2tex.R
+++ b/R/pages2tex.R
@@ -1,15 +1,21 @@
-library(lubridate)
 library(pages2df)
 
-source("R/source-folder.R")
-source("R/write-latex.R")
+pages2tex <- function(date, output_location) {
 
-today <- Sys.Date()
-this_month <- month(today)
-this_year <- year(today)
+  two_digit_year <- substr(lubridate::year(date), 3, 4)
+  two_digit_month <- sprintf("%02d", lubridate::month(date))
+  
+  chapters <- file.path(Sys.getenv("PAGESPATH"), "src", two_digit_year, two_digit_month) |>
+    pages_df() |>
+    create_chapter_df() |>
+    summarise_chapter_df()
+  
+  purrr::walk(dirname(file.path(output_location, chapters$path)), dir.create, recursive = TRUE, showWarnings = FALSE)
+  
+  purrr::walk2(.x = chapters$tex_chapter, .y = file.path(output_location, chapters$path), .f = readr::write_file)
 
-source_folder(year = this_year, month = this_month) |>
-  pages_df() |>
-  create_chapter_df() |>
-  summarise_chapter_df() |>
-  write_latex(output_location = Sys.getenv("OUTPATH"))
+}
+
+# Daily update invocation
+#
+# pages2tex(Sys.Date(), output_location = Sys.getenv("OUTPATH"))

--- a/R/source-folder.R
+++ b/R/source-folder.R
@@ -1,5 +1,0 @@
-source_folder <- function(year = 2022, month = 9) {
-  two_digit_year <- substr(year, 3, 4)
-  two_digit_month <- sprintf("%02d", month)
-  file.path(Sys.getenv("PAGESPATH"), "src", two_digit_year, two_digit_month)
-}

--- a/R/write-latex.R
+++ b/R/write-latex.R
@@ -1,4 +1,0 @@
-write_latex <- function(chapters, output_location = '.') {
-  purrr::walk(dirname(file.path(output_location, chapters$path)), dir.create, recursive = TRUE, showWarnings = FALSE)
-  purrr::walk2(.x = chapters$tex_chapter, .y = file.path(output_location, chapters$path), .f = readr::write_file)
-}


### PR DESCRIPTION
As well as writing new functions that do the same as the old scripts used to do I also removed the other two functions: `source_folder` and `write_latex`.